### PR TITLE
Refactor code structure and improve warning handling in project files

### DIFF
--- a/src/Riter/Core/RelayCommand.cs
+++ b/src/Riter/Core/RelayCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Riter.Core;
 
-public class RelayCommand(Action execute, Func<bool> canExecute = null): ICommand
+public class RelayCommand(Action execute, Func<bool> canExecute = null) : ICommand
 {
     private readonly Action _execute = execute ?? throw new ArgumentNullException(nameof(execute));
     private readonly Func<bool> _canExecute = canExecute;

--- a/src/Riter/Core/UI/SubPanels/StartupLocationPanel.xaml.cs
+++ b/src/Riter/Core/UI/SubPanels/StartupLocationPanel.xaml.cs
@@ -7,7 +7,6 @@ namespace Riter.Core.UI.SubPanels;
 /// </summary>
 public partial class StartupLocationPanel : UserControl
 {
-
     public StartupLocationPanel()
     {
         InitializeComponent();

--- a/src/Riter/MainWindow.xaml.cs
+++ b/src/Riter/MainWindow.xaml.cs
@@ -37,6 +37,19 @@ public partial class MainWindow : Window
         Loaded += MainWindow_Loaded;
     }
 
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        UnhookWindowsHookEx(_hookID);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        _hookID = SetHook(_proc);
+    }
+
     private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
@@ -51,19 +64,6 @@ public partial class MainWindow : Window
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     private static extern IntPtr GetModuleHandle(string lpModuleName);
-
-    protected override void OnClosed(EventArgs e)
-    {
-        base.OnClosed(e);
-        UnhookWindowsHookEx(_hookID);
-    }
-
-    /// <inheritdoc/>
-    protected override void OnSourceInitialized(EventArgs e)
-    {
-        base.OnSourceInitialized(e);
-        _hookID = SetHook(_proc);
-    }
 
     private static IntPtr SetHook(LowLevelKeyboardProc proc)
     {

--- a/src/Riter/Riter.csproj
+++ b/src/Riter/Riter.csproj
@@ -8,6 +8,8 @@
         <UseWPF>true</UseWPF>
         <AssemblyVersion>0.2.15</AssemblyVersion>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <NoWarn>SA1009, SA1313, SA1201, SA0001</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup>
         <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>

--- a/src/Riter/ViewModel/StateHandlers/Interfaces/IInkEditingModeStateHandler.cs
+++ b/src/Riter/ViewModel/StateHandlers/Interfaces/IInkEditingModeStateHandler.cs
@@ -24,5 +24,4 @@ public interface IInkEditingModeStateHandler : INotifyPropertyChanged
     void Ink();
 
     void None();
-
 }


### PR DESCRIPTION
I noticed a few warnings while building the project, but most of them, like [SA1009](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md), [SA1313](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md), [SA1201](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1201.md), and [SA0001](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0001.md), were pretty minor. 

To keep things tidy, I decided to suppress those warnings and treat any other warnings as errors moving forward. This way, we can maintain a warning-free project!