### PR TITLE
Refactor variable declarations to use explicit types for clarity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,15 +85,15 @@ dotnet_style_null_propagation = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,const,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
 
 # Implicit and explicit types
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false:suggestion
 
 # Expression-bodied members
 # Explicitly disabled due to difference in coding style between source and tests
 #csharp_style_expression_bodied_methods = false:silent
 #csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_operators = true:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_expression_bodied_indexers = true:suggestion
 csharp_style_expression_bodied_accessors = true:suggestion

--- a/src/Riter/App.xaml.cs
+++ b/src/Riter/App.xaml.cs
@@ -36,20 +36,20 @@ public partial class App : Application
     /// <param name="e">Event arguments for the startup event.</param>
     protected override void OnStartup(StartupEventArgs e)
     {
-        var builder = new ConfigurationBuilder()
+        IConfigurationBuilder builder = new ConfigurationBuilder()
                         .SetBasePath(Directory.GetCurrentDirectory())
                         .AddJsonFile("appsettings.json", false, true);
 
         Configuration = builder.Build();
         AppSettings appSettings = new();
         Configuration.Bind(AppSettings.Section, appSettings);
-        var serviceCollection = new ServiceCollection();
+        ServiceCollection serviceCollection = new();
         serviceCollection.AddSingleton(appSettings);
 
         ConfigureServices(serviceCollection);
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         ServiceProvider = serviceCollection.BuildServiceProvider();
-        var mainWindow = ServiceProvider.GetRequiredService<MainWindow>();
+        MainWindow mainWindow = ServiceProvider.GetRequiredService<MainWindow>();
         mainWindow.Show();
     }
 

--- a/src/Riter/Core/CursorFactory.cs
+++ b/src/Riter/Core/CursorFactory.cs
@@ -7,7 +7,7 @@ public static class CursorFactory
 {
     public static Cursor Create(DrawingShape currentShape)
     {
-        var dpi = GetDpiSuffix();
+        string dpi = GetDpiSuffix();
 
         return currentShape switch
         {
@@ -24,13 +24,13 @@ public static class CursorFactory
 
     public static Cursor CreateMoveCursor()
     {
-        var dpi = GetDpiSuffix();
+        string dpi = GetDpiSuffix();
         return new Cursor(CursorPaths.MoveCursor(dpi));
     }
 
     private static string GetDpiSuffix()
     {
-        var dpiScale = VisualTreeHelper.GetDpi(Application.Current.MainWindow);
+        DpiScale dpiScale = VisualTreeHelper.GetDpi(Application.Current.MainWindow);
         return dpiScale.PixelsPerDip > 1.5 ? "l" : "m";
     }
 }

--- a/src/Riter/Core/Drawing/ColorToGradientConverter.cs
+++ b/src/Riter/Core/Drawing/ColorToGradientConverter.cs
@@ -26,9 +26,10 @@ public class ColorToGradientConverter : IValueConverter
                 EndPoint = new Point(1, 0),
             };
         }
-        else if (value is string colorName && !string.IsNullOrEmpty(colorName))
+
+        if (value is string colorName && !string.IsNullOrEmpty(colorName))
         {
-            return new SolidColorBrush((Color)ColorConverter.ConvertFromString(colorName));
+            return new SolidColorBrush((Color)ColorConverter.ConvertFromString(colorName)!);
         }
 
         return Brushes.Transparent;

--- a/src/Riter/Core/Drawing/DrawingAttributesFactory.cs
+++ b/src/Riter/Core/Drawing/DrawingAttributesFactory.cs
@@ -18,9 +18,9 @@ public static class DrawingAttributesFactory
     /// <returns>Canvas Ink Attributes.</returns>
     public static DrawingAttributes CreateDrawingAttributes(string color, double size, bool isHighlighter)
     {
-        var drawingAttributes = new DrawingAttributes
+        DrawingAttributes drawingAttributes = new()
         {
-            Color = color == InkColor.RainBow.ToString() ? (Color)ColorConverter.ConvertFromString(GetRandomColor()) : (Color)ColorConverter.ConvertFromString(color),
+            Color = color == InkColor.RainBow.ToString() ? (Color)ColorConverter.ConvertFromString(GetRandomColor())! : (Color)ColorConverter.ConvertFromString(color)!,
             Height = isHighlighter ? size * 5 : size,
             Width = isHighlighter ? size * 5 : size,
             IsHighlighter = isHighlighter,

--- a/src/Riter/Core/Drawing/StrokesHistoryNode.cs
+++ b/src/Riter/Core/Drawing/StrokesHistoryNode.cs
@@ -4,10 +4,8 @@ using Riter.Core.Enum;
 namespace Riter.Core.Drawing;
 
 /// <summary>
-/// This objects holds the stroke that user is drawind on the canvas.
+/// This objects holds the stroke that user is drawing on the canvas.
 /// </summary>
-/// <param name="strokes">stroke line.</param>
-/// <param name="type">type of drawing added or removed.</param>
 public class StrokesHistoryNode
 {
     private StrokesHistoryNode()
@@ -26,14 +24,14 @@ public class StrokesHistoryNode
 
     public bool EnableTimer { get; private set; }
 
-    public int TimerMiliSecond { get; private set; }
+    public int TimerMilliSecond { get; private set; }
 
     public static StrokesHistoryNode CreateAddedType(StrokeCollection strokes, bool enableTimer, int timerMiliSecond) => new()
     {
         Strokes = strokes,
         Type = StrokesHistoryNodeType.Added,
         EnableTimer = enableTimer,
-        TimerMiliSecond = timerMiliSecond,
+        TimerMilliSecond = timerMiliSecond,
     };
 
     /// <summary>

--- a/src/Riter/Core/IO/FileStorage.cs
+++ b/src/Riter/Core/IO/FileStorage.cs
@@ -9,7 +9,7 @@ public class FileStorage
 
     public static async Task SaveConfig(AppSettings settings)
     {
-        var content = JsonSerializer.Serialize(new { AppSettings = settings });
+        string content = JsonSerializer.Serialize(new { AppSettings = settings });
         await File.WriteAllTextAsync(FilePath, content);
     }
 
@@ -17,13 +17,13 @@ public class FileStorage
     {
         try
         {
-            var path = $"{Directory.GetCurrentDirectory()}/Screenshots/";
+            string path = $"{Directory.GetCurrentDirectory()}/Screenshots/";
             if (!Directory.Exists(path))
             {
                 Directory.CreateDirectory(path);
             }
 
-            var filePath = Path.Combine(path, $"Screenshot_{DateTime.Now:yyyyMMddHHmmss}.png");
+            string filePath = Path.Combine(path, $"Screenshot_{DateTime.Now:yyyyMMddHHmmss}.png");
             using FileStream fileStream = new(filePath, FileMode.Create);
             PngBitmapEncoder encoder = new();
             encoder.Frames.Add(BitmapFrame.Create(renderBitmap));

--- a/src/Riter/Core/RainbowStroke.cs
+++ b/src/Riter/Core/RainbowStroke.cs
@@ -6,7 +6,7 @@ public class RainbowStroke(StylusPointCollection stylusPoints) : Stroke(stylusPo
 {
     protected override void DrawCore(DrawingContext drawingContext, DrawingAttributes drawingAttributes)
     {
-        var rainbowBrush = new LinearGradientBrush
+        LinearGradientBrush rainbowBrush = new()
         {
             GradientStops =
             [
@@ -20,7 +20,7 @@ public class RainbowStroke(StylusPointCollection stylusPoints) : Stroke(stylusPo
             StartPoint = new Point(0, 0),
             EndPoint = new Point(1, 0),
         };
-        var pathGeometry = GetGeometry(drawingAttributes);
+        Geometry pathGeometry = GetGeometry(drawingAttributes);
         drawingContext.DrawGeometry(rainbowBrush, null, pathGeometry);
     }
 }

--- a/src/Riter/Core/Shape/ArrowDrawer.cs
+++ b/src/Riter/Core/Shape/ArrowDrawer.cs
@@ -12,11 +12,11 @@ public class ArrowDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var lineAttributes = canvas.DefaultDrawingAttributes.Clone();
+        DrawingAttributes lineAttributes = canvas.DefaultDrawingAttributes.Clone();
         lineAttributes.StylusTip = StylusTip.Ellipse;
         lineAttributes.IgnorePressure = true;
 
-        var points = new List<Point> { startPoint, endPoint };
+        List<Point> points = new() { startPoint, endPoint };
 
         points.AddRange(CreateArrowheadPoints(startPoint, endPoint, 15));
         points.AddRange(CreateArrowheadPoints(startPoint, endPoint, -15));
@@ -24,7 +24,7 @@ public class ArrowDrawer : IShapeDrawer
         if (!isRainbow)
             return new Stroke(new StylusPointCollection(points)) { DrawingAttributes = lineAttributes };
 
-        var stroke = new RainbowStroke(new StylusPointCollection(points))
+        RainbowStroke stroke = new(new StylusPointCollection(points))
         {
             DrawingAttributes = canvas.DefaultDrawingAttributes.Clone(),
         };
@@ -38,12 +38,12 @@ public class ArrowDrawer : IShapeDrawer
 
         VectorX ps = new(startPoint.X, startPoint.Y);
         VectorX pe = new(endPoint.X, endPoint.Y);
-        var arrowPoint = (((ps - pe) * 0.85f) + ps).ToPoint();
+        Point arrowPoint = (((ps - pe) * 0.85f) + ps).ToPoint();
 
-        var rotatingMatrix = default(Matrix);
+        Matrix rotatingMatrix = default(Matrix);
         rotatingMatrix.RotateAt(rotation, endPoint.X, endPoint.Y);
 
-        var rotatedArrowPoint = rotatingMatrix.Transform(arrowPoint);
+        Point rotatedArrowPoint = rotatingMatrix.Transform(arrowPoint);
         arrowPoints.Add(endPoint);
         arrowPoints.Add(rotatedArrowPoint);
 

--- a/src/Riter/Core/Shape/CircleDrawer.cs
+++ b/src/Riter/Core/Shape/CircleDrawer.cs
@@ -10,16 +10,16 @@ public class CircleDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var centerX = (startPoint.X + endPoint.X) / 2;
-        var centerY = (startPoint.Y + endPoint.Y) / 2;
-        var radius = Math.Sqrt(Math.Pow(endPoint.X - centerX, 2) + Math.Pow(endPoint.Y - centerY, 2));
+        double centerX = (startPoint.X + endPoint.X) / 2;
+        double centerY = (startPoint.Y + endPoint.Y) / 2;
+        double radius = Math.Sqrt(Math.Pow(endPoint.X - centerX, 2) + Math.Pow(endPoint.Y - centerY, 2));
 
-        var points = new StylusPointCollection();
-        for (var i = 0; i <= 360; i += 5)
+        StylusPointCollection points = new();
+        for (int i = 0; i <= 360; i += 5)
         {
-            var radians = i * Math.PI / 180;
-            var x = centerX + (radius * Math.Cos(radians));
-            var y = centerY + (radius * Math.Sin(radians));
+            double radians = i * Math.PI / 180;
+            double x = centerX + (radius * Math.Cos(radians));
+            double y = centerY + (radius * Math.Sin(radians));
             points.Add(new StylusPoint(x, y));
         }
 

--- a/src/Riter/Core/Shape/DatabaseDrawer.cs
+++ b/src/Riter/Core/Shape/DatabaseDrawer.cs
@@ -12,17 +12,17 @@ public class DatabaseDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var width = Math.Abs(endPoint.X - startPoint.X);
-        var height = Math.Abs(endPoint.Y - startPoint.Y);
-        var radiusX = width / 2;
-        var centerX = (startPoint.X + endPoint.X) / 2;
-        var topY = startPoint.Y;
-        var bottomY = startPoint.Y + height;
+        double width = Math.Abs(endPoint.X - startPoint.X);
+        double height = Math.Abs(endPoint.Y - startPoint.Y);
+        double radiusX = width / 2;
+        double centerX = (startPoint.X + endPoint.X) / 2;
+        double topY = startPoint.Y;
+        double bottomY = startPoint.Y + height;
 
-        var topEllipsePoints = GetEllipsePoints(centerX, topY, radiusX, true);
+        List<Point> topEllipsePoints = GetEllipsePoints(centerX, topY, radiusX, true);
 
         List<Point> leftSideStylusPoints = [new(centerX - radiusX, topY)];
-        var bottomEllipsePoints = GetEllipsePoints(centerX, bottomY, radiusX, false);
+        List<Point> bottomEllipsePoints = GetEllipsePoints(centerX, bottomY, radiusX, false);
         List<Point> combinedPoints = [.. topEllipsePoints, .. bottomEllipsePoints, .. leftSideStylusPoints];
         return !isRainbow
             ? new Stroke(new StylusPointCollection(combinedPoints))
@@ -37,14 +37,14 @@ public class DatabaseDrawer : IShapeDrawer
 
     private static List<Point> GetEllipsePoints(double centerX, double centerY, double radiusX, bool isTop)
     {
-        var segments = 100;
-        List<Point> points = new List<Point>();
-        var angleStep = Math.PI * 2 / segments;
-        for (var i = 0; i <= segments; i++)
+        int segments = 100;
+        List<Point> points = new();
+        double angleStep = Math.PI * 2 / segments;
+        for (int i = 0; i <= segments; i++)
         {
-            var angle = angleStep * i;
-            var x = centerX + (radiusX * Math.Cos(angle));
-            var y = centerY + (radiusX / 2 * Math.Sin(angle));
+            double angle = angleStep * i;
+            double x = centerX + (radiusX * Math.Cos(angle));
+            double y = centerY + (radiusX / 2 * Math.Sin(angle));
             if (!isTop && angle > Math.PI)
             {
                 continue;

--- a/src/Riter/Core/Shape/FilledCircleDrawer.cs
+++ b/src/Riter/Core/Shape/FilledCircleDrawer.cs
@@ -11,25 +11,25 @@ public class FilledCircleDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow)
     {
-        var centerX = (startPoint.X + endPoint.X) / 2;
-        var centerY = (startPoint.Y + endPoint.Y) / 2;
-        var radius = Math.Sqrt(Math.Pow(endPoint.X - centerX, 2) + Math.Pow(endPoint.Y - centerY, 2));
+        double centerX = (startPoint.X + endPoint.X) / 2;
+        double centerY = (startPoint.Y + endPoint.Y) / 2;
+        double radius = Math.Sqrt(Math.Pow(endPoint.X - centerX, 2) + Math.Pow(endPoint.Y - centerY, 2));
 
-        var strokes = new StrokeCollection();
+        StrokeCollection strokes = new();
 
-        for (var r = radius; r >= 0; r -= 1)
+        for (double r = radius; r >= 0; r -= 1)
         {
-            var points = new StylusPointCollection();
+            StylusPointCollection points = new();
 
-            for (var angle = 0; angle <= 360; angle += 5)
+            for (int angle = 0; angle <= 360; angle += 5)
             {
-                var radians = angle * Math.PI / 180;
-                var x = centerX + (r * Math.Cos(radians));
-                var y = centerY + (r * Math.Sin(radians));
+                double radians = angle * Math.PI / 180;
+                double x = centerX + (r * Math.Cos(radians));
+                double y = centerY + (r * Math.Sin(radians));
                 points.Add(new StylusPoint(x, y));
             }
 
-            var stroke = new Stroke(points)
+            Stroke stroke = new(points)
             {
                 DrawingAttributes = canvas.DefaultDrawingAttributes.Clone(),
             };
@@ -37,15 +37,15 @@ public class FilledCircleDrawer : IShapeDrawer
             strokes.Add(stroke);
         }
 
-        var filledStroke = MergeStrokes(strokes);
+        Stroke filledStroke = MergeStrokes(strokes);
         return filledStroke;
     }
 
     private static Stroke MergeStrokes(StrokeCollection strokes)
     {
-        var allPoints = new StylusPointCollection();
+        StylusPointCollection allPoints = new();
 
-        foreach (var stroke in strokes)
+        foreach (Stroke stroke in strokes)
         {
             allPoints.Add(stroke.StylusPoints);
         }

--- a/src/Riter/Core/Shape/FilledRectangleDrawer.cs
+++ b/src/Riter/Core/Shape/FilledRectangleDrawer.cs
@@ -11,20 +11,20 @@ public class FilledRectangleDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var topLeft = new Point(Math.Min(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
-        var bottomRight = new Point(Math.Max(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
+        Point topLeft = new(Math.Min(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
+        Point bottomRight = new(Math.Max(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
 
-        var stylusPoints = new StylusPointCollection();
+        StylusPointCollection stylusPoints = new();
 
-        for (var x = topLeft.X; x <= bottomRight.X; x++)
+        for (double x = topLeft.X; x <= bottomRight.X; x++)
         {
-            for (var y = topLeft.Y; y <= bottomRight.Y; y++)
+            for (double y = topLeft.Y; y <= bottomRight.Y; y++)
             {
                 stylusPoints.Add(new StylusPoint(x, y));
             }
         }
 
-        var newAttributes = canvas.DefaultDrawingAttributes.Clone();
+        DrawingAttributes newAttributes = canvas.DefaultDrawingAttributes.Clone();
         newAttributes.StylusTip = StylusTip.Rectangle;
         newAttributes.IgnorePressure = true;
 

--- a/src/Riter/Core/Shape/LineDrawer.cs
+++ b/src/Riter/Core/Shape/LineDrawer.cs
@@ -12,7 +12,7 @@ public class LineDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var stylusPoints = new StylusPointCollection(new[]
+        StylusPointCollection stylusPoints = new(new[]
         {
             new StylusPoint(startPoint.X, startPoint.Y),
             new StylusPoint(endPoint.X, endPoint.Y),

--- a/src/Riter/Core/Shape/RectangleDrawer.cs
+++ b/src/Riter/Core/Shape/RectangleDrawer.cs
@@ -10,14 +10,14 @@ public class RectangleDrawer : IShapeDrawer
 
     public Stroke DrawShape(InkCanvas canvas, Point startPoint, Point endPoint, bool isRainbow = false)
     {
-        var topLeft = new Point(Math.Min(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
-        var topRight = new Point(Math.Max(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
-        var bottomLeft = new Point(Math.Min(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
-        var bottomRight = new Point(Math.Max(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
-        var points = new List<Point> { topLeft, topRight, bottomRight, bottomLeft, topLeft };
+        Point topLeft = new(Math.Min(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
+        Point topRight = new(Math.Max(startPoint.X, endPoint.X), Math.Min(startPoint.Y, endPoint.Y));
+        Point bottomLeft = new(Math.Min(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
+        Point bottomRight = new(Math.Max(startPoint.X, endPoint.X), Math.Max(startPoint.Y, endPoint.Y));
+        List<Point> points = new() { topLeft, topRight, bottomRight, bottomLeft, topLeft };
 
-        var stylusPoints = new StylusPointCollection(points);
-        var newAttributes = canvas.DefaultDrawingAttributes.Clone();
+        StylusPointCollection stylusPoints = new(points);
+        DrawingAttributes newAttributes = canvas.DefaultDrawingAttributes.Clone();
         newAttributes.StylusTip = StylusTip.Rectangle;
         newAttributes.IgnorePressure = true;
         return !isRainbow

--- a/src/Riter/Core/UI/MainInkCanvasControl.xaml.cs
+++ b/src/Riter/Core/UI/MainInkCanvasControl.xaml.cs
@@ -43,9 +43,9 @@ public partial class MainInkCanvasControl : UserControl
     /// <returns>A translation matrix representing the movement.</returns>
     private static Matrix CreateTranslationMatrix(Point startPoint, Point endPoint)
     {
-        var dx = endPoint.X - startPoint.X;
-        var dy = endPoint.Y - startPoint.Y;
-        var translationMatrix = default(Matrix);
+        double dx = endPoint.X - startPoint.X;
+        double dy = endPoint.Y - startPoint.Y;
+        Matrix translationMatrix = default(Matrix);
         translationMatrix.Translate(dx, dy);
         return translationMatrix;
     }
@@ -57,7 +57,7 @@ public partial class MainInkCanvasControl : UserControl
     /// <returns>True if the drawing or highlighter button is selected, otherwise false.</returns>
     private static bool IsDrawingOrHighlighterButtonSelected(PaletteStateOrchestratorViewModel viewModel)
     {
-        var selectedButton = viewModel.ButtonSelectedViewModel.ButtonSelectedName;
+        string selectedButton = viewModel.ButtonSelectedViewModel.ButtonSelectedName;
         return selectedButton == ButtonNames.DrawingButton || selectedButton == ButtonNames.HighlighterButton;
     }
 
@@ -91,7 +91,7 @@ public partial class MainInkCanvasControl : UserControl
 
     private void DrawingViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        var viewModel = (PaletteStateOrchestratorViewModel)DataContext;
+        PaletteStateOrchestratorViewModel viewModel = (PaletteStateOrchestratorViewModel)DataContext;
 
         if (e.PropertyName == nameof(viewModel.InkEditingModeViewModel.InkEditingMode)
           && viewModel.InkEditingModeViewModel.InkEditingMode is InkCanvasEditingMode.None)
@@ -131,8 +131,8 @@ public partial class MainInkCanvasControl : UserControl
 
     private void Window_KeyUp(object sender, KeyEventArgs e)
     {
-        var viewModel = (PaletteStateOrchestratorViewModel)DataContext;
-        var actualKey = ResolveActualKey(e);
+        PaletteStateOrchestratorViewModel viewModel = (PaletteStateOrchestratorViewModel)DataContext;
+        Key actualKey = ResolveActualKey(e);
 
         if (IsAltKeyReleased(actualKey))
         {
@@ -186,7 +186,7 @@ public partial class MainInkCanvasControl : UserControl
 
         if (_isDrawing && _lastStroke is not null)
         {
-            var viewModel = (PaletteStateOrchestratorViewModel)DataContext;
+            PaletteStateOrchestratorViewModel viewModel = (PaletteStateOrchestratorViewModel)DataContext;
             _strokeHistoryService.Push(
                 StrokesHistoryNode.CreateAddedType(
                 [_lastStroke],
@@ -201,7 +201,7 @@ public partial class MainInkCanvasControl : UserControl
 
     private Stroke GetStrokeUnderCursor(Point position)
     {
-        foreach (var stroke in MainInkCanvas.Strokes)
+        foreach (Stroke stroke in MainInkCanvas.Strokes)
         {
             if (stroke.HitTest(position, 2.0))
             {
@@ -218,10 +218,10 @@ public partial class MainInkCanvasControl : UserControl
 
         if (!ShouldDraw()) return;
 
-        var (viewModel, currentShape) = GetCurrentShape();
-        if (!_shapeDrawers.TryGetValue(currentShape, out var drawer)) return;
+        (PaletteStateOrchestratorViewModel viewModel, DrawingShape currentShape) = GetCurrentShape();
+        if (!_shapeDrawers.TryGetValue(currentShape, out IShapeDrawer drawer)) return;
 
-        var endPoint = e.GetPosition(MainInkCanvas);
+        Point endPoint = e.GetPosition(MainInkCanvas);
         DrawAndReplaceShape(drawer, viewModel, endPoint);
     }
 
@@ -235,8 +235,8 @@ public partial class MainInkCanvasControl : UserControl
         if (!_isDragging || _selectedStroke == null || e.LeftButton != MouseButtonState.Pressed)
             return false;
 
-        var currentPosition = e.GetPosition(MainInkCanvas);
-        var translationMatrix = CreateTranslationMatrix(_startDragPoint, currentPosition);
+        Point currentPosition = e.GetPosition(MainInkCanvas);
+        Matrix translationMatrix = CreateTranslationMatrix(_startDragPoint, currentPosition);
         _selectedStroke.Transform(translationMatrix, false);
         _startDragPoint = currentPosition;
 
@@ -257,7 +257,7 @@ public partial class MainInkCanvasControl : UserControl
     /// <param name="endPoint">The endpoint of the shape.</param>
     private void DrawAndReplaceShape(IShapeDrawer drawer, PaletteStateOrchestratorViewModel viewModel, Point endPoint)
     {
-        var stroke = drawer.DrawShape(MainInkCanvas, _startPoint, endPoint, viewModel.BrushSettingsViewModel.IsRainbow);
+        Stroke stroke = drawer.DrawShape(MainInkCanvas, _startPoint, endPoint, viewModel.BrushSettingsViewModel.IsRainbow);
 
         if (_lastStroke != null)
             MainInkCanvas.Strokes.Remove(_lastStroke);
@@ -272,8 +272,8 @@ public partial class MainInkCanvasControl : UserControl
     /// <returns>A tuple containing the palette state view model and the current drawing shape.</returns>
     private (PaletteStateOrchestratorViewModel viewModel, DrawingShape currentShape) GetCurrentShape()
     {
-        var viewModel = (PaletteStateOrchestratorViewModel)DataContext;
-        var currentShape = viewModel.DrawingViewModel.CurrentShape;
+        PaletteStateOrchestratorViewModel viewModel = (PaletteStateOrchestratorViewModel)DataContext;
+        DrawingShape currentShape = viewModel.DrawingViewModel.CurrentShape;
 
         if (viewModel.ButtonSelectedViewModel.ButtonSelectedName == ButtonNames.DrawingButton ||
             viewModel.ButtonSelectedViewModel.ButtonSelectedName == ButtonNames.HighlighterButton)
@@ -297,7 +297,7 @@ public partial class MainInkCanvasControl : UserControl
             return;
         }
 
-        var viewModel = (PaletteStateOrchestratorViewModel)DataContext;
+        PaletteStateOrchestratorViewModel viewModel = (PaletteStateOrchestratorViewModel)DataContext;
 
         if (e.Added.Count != 0)
         {

--- a/src/Riter/Core/UI/SubPanels/DrawingShapePanel.xaml.cs
+++ b/src/Riter/Core/UI/SubPanels/DrawingShapePanel.xaml.cs
@@ -11,9 +11,9 @@ public partial class DrawingShapePanel : UserControl
     public DrawingShapePanel()
     {
         InitializeComponent();
-        var appSetting = App.ServiceProvider.GetService<AppSettings>();
+        AppSettings appSetting = App.ServiceProvider.GetService<AppSettings>();
 
-        var hotkeys = appSetting.HotKeysConfig.ToDictionary(x => x.Key, x => x.Value);
+        Dictionary<string, string> hotkeys = appSetting.HotKeysConfig.ToDictionary(x => x.Key, x => x.Value);
         ArrowHotKey.Content = hotkeys[HotKey.Arrow.ToString()];
         LineHotKey.Content = hotkeys[HotKey.Line.ToString()];
         RectangleHotKey.Content = hotkeys[HotKey.Rectangle.ToString()];

--- a/src/Riter/Core/UI/SubPanels/KeyboardHotKeys.xaml.cs
+++ b/src/Riter/Core/UI/SubPanels/KeyboardHotKeys.xaml.cs
@@ -64,7 +64,7 @@ public partial class KeyboardHotKeys : UserControl
             return;
         }
 
-        var keyCombinationBuilder = new StringBuilder();
+        StringBuilder keyCombinationBuilder = new();
 
         if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
         {
@@ -83,11 +83,11 @@ public partial class KeyboardHotKeys : UserControl
 
         keyCombinationBuilder.Append(e.Key.ToString().ToUpper());
 
-        var keyCombination = keyCombinationBuilder.ToString();
+        string keyCombination = keyCombinationBuilder.ToString();
         focusedTextBox.Text = keyCombination;
         e.Handled = true;
 
-        var hotKeyConfig = _settings.HotKeysConfig.Where(x => x.Key == focusedTextBox.Name).FirstOrDefault();
+        HotKeysConfig hotKeyConfig = _settings.HotKeysConfig.Where(x => x.Key == focusedTextBox.Name).FirstOrDefault();
 
         if (hotKeyConfig is not null)
         {

--- a/src/Riter/Core/UI/SubPanels/StrokeSizePanel.xaml.cs
+++ b/src/Riter/Core/UI/SubPanels/StrokeSizePanel.xaml.cs
@@ -14,9 +14,9 @@ public partial class StrokeSizePanel : UserControl
     public StrokeSizePanel()
     {
         InitializeComponent();
-        var appSetting = App.ServiceProvider.GetService<AppSettings>();
+        AppSettings appSetting = App.ServiceProvider.GetService<AppSettings>();
 
-        var hotkeys = appSetting.HotKeysConfig.ToDictionary(x => x.Key, x => x.Value);
+        Dictionary<string, string> hotkeys = appSetting.HotKeysConfig.ToDictionary(x => x.Key, x => x.Value);
         Stroke07XHotKey.Content = hotkeys[HotKey.SizeOfBrush07X.ToString()].Replace("D1", "1");
         Stroke1XHotKey.Content = hotkeys[HotKey.SizeOfBrush1X.ToString()].Replace("D2", "2");
         Stroke2XHotKey.Content = hotkeys[HotKey.SizeOfBrush2X.ToString()].Replace("D3", "3");

--- a/src/Riter/Core/WindowExtensions/WindowDragableExtensions.cs
+++ b/src/Riter/Core/WindowExtensions/WindowDragableExtensions.cs
@@ -51,8 +51,8 @@ public static class WindowDraggableExtensions
             return;
         }
 
-        var currentMousePosition = e.GetPosition(window);
-        var offset = currentMousePosition - _lastMousePosition;
+        Point currentMousePosition = e.GetPosition(window);
+        Vector offset = currentMousePosition - _lastMousePosition;
 
         if (element.RenderTransform is TranslateTransform transform)
         {

--- a/src/Riter/Core/WindowExtensions/WindowLocationStrategy.cs
+++ b/src/Riter/Core/WindowExtensions/WindowLocationStrategy.cs
@@ -7,10 +7,10 @@ public class BottomCenterStrategy : IStartupLocationStrategy
 {
     public void AdjustSize(Grid layout, StackPanel mainPalette, AppSettings appSettings)
     {
-        var canvasWidth = layout.ActualWidth;
-        var canvasHeight = layout.ActualHeight;
-        var paletteWidth = mainPalette.ActualWidth;
-        var paletteHeight = mainPalette.ActualHeight;
+        double canvasWidth = layout.ActualWidth;
+        double canvasHeight = layout.ActualHeight;
+        double paletteWidth = mainPalette.ActualWidth;
+        double paletteHeight = mainPalette.ActualHeight;
 
         Canvas.SetLeft(mainPalette, (canvasWidth - paletteWidth) / 2);
         Canvas.SetTop(mainPalette, canvasHeight - paletteHeight - 75);
@@ -21,8 +21,8 @@ public class BottomLeftStrategy : IStartupLocationStrategy
 {
     public void AdjustSize(Grid layout, StackPanel mainPalette, AppSettings appSettings)
     {
-        var canvasHeight = layout.ActualHeight;
-        var paletteHeight = mainPalette.ActualHeight;
+        double canvasHeight = layout.ActualHeight;
+        double paletteHeight = mainPalette.ActualHeight;
 
         Canvas.SetLeft(mainPalette, 75);
         Canvas.SetTop(mainPalette, canvasHeight - paletteHeight - 75);
@@ -33,10 +33,10 @@ public class BottomRightStrategy : IStartupLocationStrategy
 {
     public void AdjustSize(Grid layout, StackPanel mainPalette, AppSettings appSettings)
     {
-        var canvasWidth = layout.ActualWidth;
-        var canvasHeight = layout.ActualHeight;
-        var paletteWidth = mainPalette.ActualWidth;
-        var paletteHeight = mainPalette.ActualHeight;
+        double canvasWidth = layout.ActualWidth;
+        double canvasHeight = layout.ActualHeight;
+        double paletteWidth = mainPalette.ActualWidth;
+        double paletteHeight = mainPalette.ActualHeight;
 
         Canvas.SetLeft(mainPalette, canvasWidth - paletteWidth - 75);
         Canvas.SetTop(mainPalette, canvasHeight - paletteHeight - 75);
@@ -47,10 +47,10 @@ public class CenterStrategy : IStartupLocationStrategy
 {
     public void AdjustSize(Grid layout, StackPanel mainPalette, AppSettings appSettings)
     {
-        var canvasWidth = layout.ActualWidth;
-        var canvasHeight = layout.ActualHeight;
-        var paletteWidth = mainPalette.ActualWidth;
-        var paletteHeight = mainPalette.ActualHeight;
+        double canvasWidth = layout.ActualWidth;
+        double canvasHeight = layout.ActualHeight;
+        double paletteWidth = mainPalette.ActualWidth;
+        double paletteHeight = mainPalette.ActualHeight;
         Canvas.SetLeft(mainPalette, (canvasWidth - paletteWidth) / 2);
         Canvas.SetTop(mainPalette, (canvasHeight - paletteHeight - 440) / 2);
     }

--- a/src/Riter/MainWindow.xaml.cs
+++ b/src/Riter/MainWindow.xaml.cs
@@ -67,17 +67,17 @@ public partial class MainWindow : Window
 
     private static IntPtr SetHook(LowLevelKeyboardProc proc)
     {
-        using var curProcess = Process.GetCurrentProcess();
-        using var curModule = curProcess.MainModule;
+        using Process curProcess = Process.GetCurrentProcess();
+        using ProcessModule curModule = curProcess.MainModule;
         return SetWindowsHookEx(WHKEYBOARDLL, proc, GetModuleHandle(curModule.ModuleName), 0);
     }
 
     private static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
-        var isKey = true;
+        bool isKey = true;
         if (nCode >= 0 && (wParam == WMKEYDOWN || wParam == WMKEYUP))
         {
-            var vkCode = Marshal.ReadInt32(lParam);
+            int vkCode = Marshal.ReadInt32(lParam);
 
             if (wParam is WMKEYDOWN)
             {
@@ -131,7 +131,7 @@ public partial class MainWindow : Window
     {
         if (MainPalette != null)
         {
-            var context = new StartupLocationContext(_appSettings.StartupLocation);
+            StartupLocationContext context = new(_appSettings.StartupLocation);
             context.ExecuteStrategy(Layout, MainPalette, _appSettings);
         }
     }

--- a/src/Riter/Riter.csproj
+++ b/src/Riter/Riter.csproj
@@ -8,7 +8,7 @@
         <UseWPF>true</UseWPF>
         <AssemblyVersion>0.2.15</AssemblyVersion>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-        <NoWarn>SA1009, SA1313, SA1201, SA0001</NoWarn>
+        <NoWarn>SA1009, SA1313, SA1201, SA0001, SA1623</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup>

--- a/src/Riter/Services/HotkeyCommandService.cs
+++ b/src/Riter/Services/HotkeyCommandService.cs
@@ -10,15 +10,15 @@ public class HotKeyCommandService(AppSettings appSettings)
 
     public void ExecuteHotKey(HotKeiesPressed hotKeies)
     {
-        var keiesMap = BuildKeyCombination(hotKeies);
-        var hotkey = _appSettings.HotKeysConfig.FirstOrDefault(x => x.Value == keiesMap);
+        string keiesMap = BuildKeyCombination(hotKeies);
+        HotKeysConfig hotkey = _appSettings.HotKeysConfig.FirstOrDefault(x => x.Value == keiesMap);
 
         if (hotkey is null || !Enum.TryParse(hotkey.Key, out HotKey hotKeyEnum))
         {
             return;
         }
 
-        if (_hotKeyCommandMap.TryGetValue(hotKeyEnum, out var command))
+        if (_hotKeyCommandMap.TryGetValue(hotKeyEnum, out Action command))
         {
             command.Invoke();
         }
@@ -26,7 +26,7 @@ public class HotKeyCommandService(AppSettings appSettings)
 
     private static string BuildKeyCombination(HotKeiesPressed hotKeies)
     {
-        var keiesMap = new StringBuilder();
+        StringBuilder keiesMap = new();
 
         if (hotKeies.CtrlPressed)
         {

--- a/src/Riter/Services/StrokeHistoryService.cs
+++ b/src/Riter/Services/StrokeHistoryService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Controls;
+using System.Windows.Ink;
 using System.Windows.Media;
 using System.Windows.Threading;
 using System.Xml.Linq;
@@ -41,7 +42,7 @@ public class StrokeHistoryService : IStrokeHistoryService
     public void Clear()
     {
         _history.Clear();
-        foreach (var timer in _fadeTimers.Values)
+        foreach (DispatcherTimer timer in _fadeTimers.Values)
         {
             timer.Stop();
         }
@@ -79,7 +80,7 @@ public class StrokeHistoryService : IStrokeHistoryService
         }
 
         _ignoreStrokesChange = true;
-        var lastItem = _redoHistory.Pop();
+        StrokesHistoryNode lastItem = _redoHistory.Pop();
         if (lastItem.Type == StrokesHistoryNodeType.Removed)
         {
             InkCanvas.Strokes.Remove(lastItem.Strokes);
@@ -102,7 +103,7 @@ public class StrokeHistoryService : IStrokeHistoryService
         }
 
         _ignoreStrokesChange = true;
-        var lastItem = Pop();
+        StrokesHistoryNode lastItem = Pop();
         if (lastItem.Type == StrokesHistoryNodeType.Added)
         {
             InkCanvas.Strokes.Remove(lastItem.Strokes);
@@ -118,21 +119,21 @@ public class StrokeHistoryService : IStrokeHistoryService
 
     private void StartFadeAnimation(StrokesHistoryNode node)
     {
-        foreach (var stroke in node.Strokes)
+        foreach (Stroke stroke in node.Strokes)
         {
-            var drawingAttributes = stroke.DrawingAttributes;
-            var initialColor = drawingAttributes.Color;
-            var duration = TimeSpan.FromMilliseconds(node.TimerMiliSecond);
-            var steps = 30;
-            var interval = duration.TotalMilliseconds / steps;
-            var opacityStep = initialColor.A / (float)steps;
+            DrawingAttributes drawingAttributes = stroke.DrawingAttributes;
+            Color initialColor = drawingAttributes.Color;
+            TimeSpan duration = TimeSpan.FromMilliseconds(node.TimerMilliSecond);
+            int steps = 30;
+            double interval = duration.TotalMilliseconds / steps;
+            float opacityStep = initialColor.A / (float)steps;
 
-            var timer = new DispatcherTimer
+            DispatcherTimer timer = new()
             {
                 Interval = TimeSpan.FromMilliseconds(interval),
             };
 
-            var currentStep = 0;
+            int currentStep = 0;
 
             timer.Tick += (s, e) =>
             {
@@ -144,7 +145,7 @@ public class StrokeHistoryService : IStrokeHistoryService
                 }
 
                 currentStep++;
-                var newAlpha = (byte)Math.Max(0, initialColor.A - (opacityStep * currentStep));
+                byte newAlpha = (byte)Math.Max(0, initialColor.A - (opacityStep * currentStep));
                 drawingAttributes.Color = Color.FromArgb(newAlpha, initialColor.R, initialColor.G, initialColor.B);
             };
 

--- a/src/Riter/ViewModel/StateHandlers/BrushSettingsStateHandler.cs
+++ b/src/Riter/ViewModel/StateHandlers/BrushSettingsStateHandler.cs
@@ -71,7 +71,7 @@ public class BrushSettingsStateHandler : BaseStateHandler, IBrushSettingsStateHa
 
     public void SetSizeOfBrush(string size)
     {
-        if (double.TryParse(size, out var parsedSize))
+        if (double.TryParse(size, out double parsedSize))
         {
             SizeOfBrush = parsedSize;
             ResetSettings();

--- a/src/Riter/ViewModel/StateHandlers/ScreenShotHandler.cs
+++ b/src/Riter/ViewModel/StateHandlers/ScreenShotHandler.cs
@@ -9,16 +9,16 @@ public class ScreenShotHandler : BaseStateHandler, IScreenShotHandler
 {
     public void Take()
     {
-        var mainWindow = (MainWindow)Application.Current.MainWindow;
+        MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
         try
         {
             mainWindow.MainPalette.Visibility = Visibility.Collapsed;
             mainWindow.Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
-            var bounds = VisualTreeHelper.GetDescendantBounds(mainWindow.MainInkCanvasControl.MainInkCanvas);
+            Rect bounds = VisualTreeHelper.GetDescendantBounds(mainWindow.MainInkCanvasControl.MainInkCanvas);
             RenderTargetBitmap renderBitmap = new((int)bounds.Width, (int)bounds.Height, 96d, 96d, PixelFormats.Pbgra32);
 
             DrawingVisual visual = new();
-            using (var context = visual.RenderOpen())
+            using (DrawingContext context = visual.RenderOpen())
             {
                 VisualBrush brush = new(mainWindow.MainInkCanvasControl.MainInkCanvas);
                 context.DrawRectangle(brush, null, new Rect(default, bounds.Size));

--- a/tests/Riter.Tests/Services/StrokeHistoryServiceTests.cs
+++ b/tests/Riter.Tests/Services/StrokeHistoryServiceTests.cs
@@ -25,17 +25,17 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void Push_ShouldAddNodeToHistory()
     {
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added);
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added);
         _service.Push(node);
-        var poppedNode = _service.Pop();
+        StrokesHistoryNode poppedNode = _service.Pop();
         poppedNode.Should().BeSameAs(node, "because the node should be pushed to the undo history");
     }
 
     [WpfFact]
     public void Clear_ShouldResetAllHistoriesAndStrokes()
     {
-        var strokes = new StrokeCollection();
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
+        StrokeCollection strokes = new();
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
         _service.Push(node);
 
         _service.Clear();
@@ -48,10 +48,10 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void Push_ShouldAddHistoryNode_ToUndoStack()
     {
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added);
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added);
 
         _service.Push(node);
-        var result = _service.Pop();
+        StrokesHistoryNode result = _service.Pop();
 
         Assert.Equal(node, result);
     }
@@ -59,7 +59,7 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void CanUndo_ShouldReturnTrue_WhenHistoryStackIsNotEmpty()
     {
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added);
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added);
         _service.Push(node);
 
         Assert.True(_service.CanUndo());
@@ -74,8 +74,8 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void Undo_ShouldMoveNode_FromHistoryToRedoStack()
     {
-        var strokes = new StrokeCollection();
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
+        StrokeCollection strokes = new();
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
 
         _service.Push(node);
         _service.Undo();
@@ -87,8 +87,8 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void Redo_ShouldMoveNode_FromRedoToHistoryStack()
     {
-        var strokes = new StrokeCollection();
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Removed, strokes);
+        StrokeCollection strokes = new();
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Removed, strokes);
 
         _service.Push(node);
         _service.Undo();
@@ -101,8 +101,8 @@ public class StrokeHistoryServiceTests
     [WpfFact]
     public void ClearRedoHistory_ShouldOnlyClearRedoStack()
     {
-        var strokes = new StrokeCollection();
-        var node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
+        StrokeCollection strokes = new();
+        StrokesHistoryNode node = CreateHistoryNode(StrokesHistoryNodeType.Added, strokes);
 
         _service.Push(node);
         _service.Undo();

--- a/tests/Riter.Tests/ViewModel/StateHandlers/BrushSettingsStateHandlerTests.cs
+++ b/tests/Riter.Tests/ViewModel/StateHandlers/BrushSettingsStateHandlerTests.cs
@@ -29,7 +29,7 @@ public class BrushSettingsStateHandlerTests
     public void Should_UpdateInkColorAndColorSelected_When_SetInkColorIsCalled()
     {
 
-        var newColor = "Red";
+        string newColor = "Red";
         _brushSettingsStateHandler.SetInkColor(newColor);
 
         _brushSettingsStateHandler.InkColor.Should().Be(newColor);
@@ -42,7 +42,7 @@ public class BrushSettingsStateHandlerTests
     [Fact]
     public void Should_UpdateInkColor_When_SetInkColorWithHotKeyIsCalled()
     {
-        var color = InkColor.Red;
+        InkColor color = InkColor.Red;
         _brushSettingsStateHandler.SetInkColorWithHotKey(color);
         _brushSettingsStateHandler.InkColor.Should().Be(ColorPalette.Colors[color].Hex);
     }
@@ -50,7 +50,7 @@ public class BrushSettingsStateHandlerTests
     [Fact]
     public void Should_UpdateSizeOfBrush_When_SetSizeOfBrushIsCalled()
     {
-        var newSize = "5.0";
+        string newSize = "5.0";
         _brushSettingsStateHandler.SetSizeOfBrush(newSize);
 
         _brushSettingsStateHandler.SizeOfBrush.Should().Be(5.0);
@@ -62,7 +62,7 @@ public class BrushSettingsStateHandlerTests
     [Fact]
     public void Should_UpdateSizeOfBrush_When_SetSizeOfBrushWithHotKeyIsCalled()
     {
-        var newSize = BrushSize.X2;
+        BrushSize newSize = BrushSize.X2;
         _brushSettingsStateHandler.SetSizeOfBrushWithHotKey(newSize);
         _brushSettingsStateHandler.SizeOfBrush.Should().Be((double)newSize);
     }

--- a/tests/Riter.Tests/ViewModel/StateHandlers/ButtonSelectedStateHandlerTests.cs
+++ b/tests/Riter.Tests/ViewModel/StateHandlers/ButtonSelectedStateHandlerTests.cs
@@ -13,7 +13,7 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_UpdateButtonSelectedName_When_SetButtonSelectedNameIsCalled()
     {
-        var newButtonName = "NewButton";
+        string newButtonName = "NewButton";
         _stateHandler.SetButtonSelectedName(newButtonName);
         _stateHandler.ButtonSelectedName.Should().Be(newButtonName);
     }
@@ -21,8 +21,8 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_ResetButtonSelectedNameToPrevious_When_ResetPreviousButtonIsCalled()
     {
-        var initialButtonName = "InitialButton";
-        var newButtonName = "NewButton";
+        string initialButtonName = "InitialButton";
+        string newButtonName = "NewButton";
         _stateHandler.SetButtonSelectedName(initialButtonName);
         _stateHandler.StoreCurrentButton();
         _stateHandler.SetButtonSelectedName(newButtonName);
@@ -34,7 +34,7 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_ClearPreviousButtonSelectedName_When_ResetPreviousButtonIsCalledTwice()
     {
-        var initialButtonName = "InitialButton";
+        string initialButtonName = "InitialButton";
         _stateHandler.SetButtonSelectedName(initialButtonName);
         _stateHandler.StoreCurrentButton();
         _stateHandler.ResetPreviousButton();
@@ -45,7 +45,7 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_StoreCurrentButtonSelectedName_When_StoreCurrentButtonIsCalled()
     {
-        var initialButtonName = "InitialButton";
+        string initialButtonName = "InitialButton";
         _stateHandler.SetButtonSelectedName(initialButtonName);
 
         _stateHandler.StoreCurrentButton();
@@ -57,7 +57,7 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_ResetArrowButtonSelectedName_When_ResetArrowButtonSelectedIsCalled()
     {
-        var arrowButtonName = "ArrowButton";
+        string arrowButtonName = "ArrowButton";
         _stateHandler.SetArrowButtonSelected(arrowButtonName);
 
         _stateHandler.ResetArrowButtonSelected();
@@ -67,7 +67,7 @@ public class ButtonSelectedStateHandlerTests
     [Fact]
     public void Should_UpdateArrowButtonSelectedName_When_SetArrowButtonSelectedIsCalled()
     {
-        var arrowButtonName = "ArrowButton";
+        string arrowButtonName = "ArrowButton";
         _stateHandler.SetArrowButtonSelected(arrowButtonName);
         _stateHandler.ArrowButtonSelectedName.Should().Be(arrowButtonName);
     }


### PR DESCRIPTION
In this PR, I made a few small changes to enhance the code's clarity. I used variable declarations with **explicit types** for better understanding, fixed some **typos**, and suppressed the warning for [SA1623](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md). 

These changes won’t affect the program’s operation, just a little polish for improved readability!