### PR TITLE
Bug Fix: Toolbox Not Moving Between Multiple Monitors

### DIFF
--- a/src/Riter/Core/UI/SubPanels/UpdatePanel.xaml.cs
+++ b/src/Riter/Core/UI/SubPanels/UpdatePanel.xaml.cs
@@ -62,7 +62,7 @@ public partial class UpdatePanel : UserControl
             ?? throw new Exception("Unable to determine file size.");
 
         await using Stream contentStream = await response.Content.ReadAsStreamAsync();
-        await using FileStream fileStream = new (
+        await using FileStream fileStream = new(
             destinationPath,
             FileMode.Create,
             FileAccess.Write,

--- a/src/Riter/MainWindow.xaml
+++ b/src/Riter/MainWindow.xaml
@@ -11,7 +11,7 @@
     mc:Ignorable="d" ResizeMode="NoResize"
     UseLayoutRounding="True" 
     WindowStartupLocation="Manual"
-    WindowState="Maximized"
+    WindowState="Normal"
     AllowsTransparency="True" 
     WindowStyle="None">
 

--- a/src/Riter/MainWindow.xaml.cs
+++ b/src/Riter/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows;
 using Riter.Core.WindowExtensions;
 using Riter.ViewModel;
 
@@ -48,6 +49,9 @@ public partial class MainWindow : Window
     {
         base.OnSourceInitialized(e);
         _hookID = SetHook(_proc);
+
+        // Set the window to cover the entire virtual desktop area
+        SetWindowToVirtualDesktop();
     }
 
     private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
@@ -120,11 +124,36 @@ public partial class MainWindow : Window
     /// <summary>
     /// Load the window in bottom center of screen.
     /// </summary>
+    /// <param name="sender">The sender of the event.</param>
     /// <param name="e">Contains the data of routed event.</param>
     private void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
+        SetWindowToVirtualDesktop();
         AdjustWindowSize();
-        Microsoft.Win32.SystemEvents.DisplaySettingsChanged += (_, _) => AdjustWindowSize();
+        Microsoft.Win32.SystemEvents.DisplaySettingsChanged += (_, _) =>
+        {
+            SetWindowToVirtualDesktop();
+            AdjustWindowSize();
+        };
+    }
+
+    /// <summary>
+    /// Sets the window to cover the entire virtual desktop area across all monitors.
+    /// </summary>
+    private void SetWindowToVirtualDesktop()
+    {
+        // Set window position and size to cover the entire virtual desktop
+        this.Left = SystemParameters.VirtualScreenLeft;
+        this.Top = SystemParameters.VirtualScreenTop;
+        this.Width = SystemParameters.VirtualScreenWidth;
+        this.Height = SystemParameters.VirtualScreenHeight;
+
+        // Ensure the layout grid fills the entire window
+        if (Layout != null)
+        {
+            Layout.Width = this.Width;
+            Layout.Height = this.Height;
+        }
     }
 
     private void AdjustWindowSize()

--- a/tests/Riter.Tests/ViewModel/StateHandlers/SettingsPanelStateHandlerTests.cs
+++ b/tests/Riter.Tests/ViewModel/StateHandlers/SettingsPanelStateHandlerTests.cs
@@ -19,7 +19,7 @@ public class SettingsPanelStateHandlerTests
     [Fact]
     public void Should_HideAllPanels_When_HideAllPanelsIsCalled()
     {
-        
+
         _handler.HideAllPanels();
 
         _handler.SettingPanelVisibility.Should().BeFalse();
@@ -34,7 +34,7 @@ public class SettingsPanelStateHandlerTests
     [Fact]
     public void Should_SetSettingPanelVisibilityToTrue_When_SetSettingPanelVisibleIsCalled()
     {
-        
+
         _handler.SetSettingPanelVisibile();
         _handler.SettingPanelVisibility.Should().BeTrue();
     }
@@ -58,7 +58,7 @@ public class SettingsPanelStateHandlerTests
     public void Should_HideAllPanelsAndResetArrowButton_When_ToggleBrushSettingsPanelIsCalledWithSameButton()
     {
         _mockButtonSelectedStateHandler.SetupGet(m => m.ArrowButtonSelectedName).Returns("BrushButton");
-        
+
         _handler.ToggleBrushSettingsPanel("BrushButton");
 
         _handler.BrushPanelVisibility.Should().BeTrue();
@@ -73,7 +73,7 @@ public class SettingsPanelStateHandlerTests
     public void Should_ShowBrushPanel_When_ToggleBrushSettingsPanelIsCalledWithDifferentButton()
     {
         _handler.ToggleBrushSettingsPanel("NewBrushButton");
-        
+
         _handler.BrushPanelVisibility.Should().BeTrue();
         _mockButtonSelectedStateHandler.Verify(m => m.SetArrowButtonSelected(ButtonNames.ChangeBrushSettingButton), Times.Once);
     }

--- a/tests/Riter.Tests/ViewModel/StateHandlers/StrokeVisibilityStateHandlerTests.cs
+++ b/tests/Riter.Tests/ViewModel/StateHandlers/StrokeVisibilityStateHandlerTests.cs
@@ -21,7 +21,7 @@ public class StrokeVisibilityStateHandlerTests
     public void Should_Toggle_IsHideAll_When_HideAll_Is_Called()
     {
         _handler.HideAll();
-        _handler.IsHideAll.Should().BeTrue(); 
+        _handler.IsHideAll.Should().BeTrue();
 
         _handler.HideAll();
         _handler.IsHideAll.Should().BeFalse();


### PR DESCRIPTION
This PR addresses the bug that caused the toolbox to disappear when being moved between multiple monitors.

Summary of the Problem
The main window was not properly configured to cover the entire virtual desktop area (all monitors), which caused the toolbox to disappear when it was dragged to a different screen.

Changes Made
To resolve this issue, several key changes were implemented:

    The MainWindow class was updated to use the SystemParameters.VirtualScreenLeft, SystemParameters.VirtualScreenTop, SystemParameters.VirtualScreenWidth, and SystemParameters.VirtualScreenHeight properties to ensure it spans the entire virtual desktop.

    The window configuration was changed from the Maximized state to Normal to provide better multi-monitor support.

    A new method called SetWindowToVirtualDesktop() was implemented to correctly position the window across all monitors and handle changes to display settings.

    The Canvas within the window was ensured to be properly sized to accommodate the full virtual desktop area.

Result
With these changes, the toolbox can now be dragged freely between monitors without disappearing. The main window spans all monitors, providing a large enough canvas for the toolbox to be positioned anywhere. The fix has been successfully implemented and tested.